### PR TITLE
Api redesign

### DIFF
--- a/impl-service/src/lib.rs
+++ b/impl-service/src/lib.rs
@@ -68,11 +68,8 @@ pub fn middleware(_attribute: TokenStream, function: TokenStream) -> TokenStream
 	let output = quote! {
 		struct #ident;
 		
-		impl MiddleWare for #ident
-		{
-			type R = Response;
-			type E = ArcError;
-			fn call(&self, #inputs) -> ArcResult<Self::R, Self::E> {
+		impl MiddleWare for #ident {
+			fn call(&self, #inputs) -> ArcResult {
 				#(
 					#block
 				)*

--- a/src/ArcCore/mod.rs
+++ b/src/ArcCore/mod.rs
@@ -1,5 +1,9 @@
 mod handler;
 mod reactor;
+mod request;
+mod response;
 
 pub use self::reactor::*;
 pub use self::handler::*;
+pub use self::request::*;
+pub use self::response::*;

--- a/src/ArcCore/request.rs
+++ b/src/ArcCore/request.rs
@@ -1,0 +1,72 @@
+use hyper::{Uri, Body, HttpVersion, Headers, Method};
+use std::{fmt, net};
+
+pub struct Request {
+	uri: Uri,
+	body: Body,
+	version: HttpVersion,
+	headers: Headers,
+	remote: Option<net::SocketAddr>,
+	method: Method,
+}
+
+impl Request {
+	pub fn new(
+		method: Method,
+		uri: Uri,
+		version: HttpVersion,
+		headers: Headers,
+		body: Body,
+		remote: Option<net::SocketAddr>
+	) -> Self {
+		Self {
+			method,
+			uri,
+			version,
+			headers,
+			body,
+			remote
+		}
+	}
+	
+	#[inline]
+	pub fn version(&self) -> &HttpVersion {
+		&self.version
+	}
+	
+	#[inline]
+	pub fn headers(&self) -> &Headers {
+		&self.headers
+	}
+	
+	#[inline]
+	pub fn method(&self) -> &Method {
+		&self.method
+	}
+	
+	#[inline]
+	pub fn uri(&self) -> &Uri {
+		&self.uri
+	}
+	
+	#[inline]
+	pub fn path(&self) -> &str {
+		self.uri.path()
+	}
+
+	pub fn query(&self) -> Option<&str> {
+		self.uri.query()
+	}
+}
+
+impl fmt::Debug for Request {
+	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+		f.debug_struct("Request")
+			.field("method", &self.method)
+			.field("uri", &self.uri)
+			.field("version", &self.version)
+			.field("remote", &self.remote)
+			.field("headers", &self.headers)
+			.finish()
+	}
+}

--- a/src/ArcCore/response.rs
+++ b/src/ArcCore/response.rs
@@ -1,0 +1,106 @@
+use hyper;
+use hyper::header::{Header, Headers, Location};
+use hyper::{Body, HttpVersion, StatusCode};
+
+#[derive(Debug)]
+pub struct Response {
+	pub(crate) inner: hyper::Response,
+}
+
+impl Response {
+	pub fn new () -> Self {
+		Response::default()
+	}
+	
+	/// Get the HTTP version of this response.
+	#[inline]
+	pub fn version(&self) -> HttpVersion { self.inner.version() }
+	
+	/// Get the headers from the response.
+	#[inline]
+	pub fn headers(&self) -> &Headers { self.inner.headers() }
+	
+	/// Get a mutable reference to the headers.
+	#[inline]
+	pub fn headers_mut(&mut self) -> &mut Headers { self.inner.headers_mut() }
+	
+	/// Get the status from the server.
+	#[inline]
+	pub fn status(&self) -> StatusCode { self.inner.status() }
+	
+	/// Set the `StatusCode` for this response.
+	#[inline]
+	pub fn set_status(&mut self, status: StatusCode) {
+		self.inner.set_status(status);
+	}
+	
+	/// Set the status and move the Response.
+	///
+	/// Useful for the "builder-style" pattern.
+	#[inline]
+	pub fn with_status(mut self, status: StatusCode) -> Self {
+		self.inner = self.inner.with_status(status);
+		self
+	}
+	
+	/// Set a header and move the Response.
+	///
+	/// Useful for the "builder-style" pattern.
+	#[inline]
+	pub fn with_header<H: Header>(mut self, header: H) -> Self {
+		self.inner = self.inner.with_header(header);
+		self
+	}
+	
+	/// Set the headers and move the Response.
+	///
+	/// Useful for the "builder-style" pattern.
+	#[inline]
+	pub fn with_headers(mut self, headers: Headers) -> Self {
+		self.inner = self.inner.with_headers(headers);
+		self
+	}
+	
+	/// Set the body.
+	#[inline]
+	pub fn set_body<T: Into<Body>>(&mut self, body: T) {
+		self.inner.set_body(body);
+	}
+	
+	/// Set the body and move the Response.
+	///
+	/// Useful for the "builder-style" pattern.
+	#[inline]
+	pub fn with_body<T: Into<Body>>(mut self, body: T) -> Self {
+		self.inner = self.inner.with_body(body);
+		self
+	}
+	
+	/// Read the body.
+	#[inline]
+	pub fn body_ref(&self) -> Option<&Body> { self.inner.body_ref() }
+	
+	pub fn redirect(url: &'static str) -> hyper::Response {
+		let mut headers = Headers::new();
+		headers.set(Location::new(url));
+		Response::new()
+			.with_status(StatusCode::MovedPermanently)
+			.with_headers(headers)
+			.inner
+	}
+	
+	pub fn badRequest() -> hyper::Response {
+		Response::new()
+			.with_status(StatusCode::BadRequest)
+			.inner
+	}
+}
+
+impl Default for Response {
+	fn default() -> Response {
+		Response {
+			inner: hyper::Response::default()
+		}
+	}
+}
+

--- a/src/ArcProto/convert.rs
+++ b/src/ArcProto/convert.rs
@@ -1,0 +1,35 @@
+use hyper::{StatusCode, self};
+use ArcProto::{ArcError};
+use ArcCore::{Response};
+
+fn convertToStatusCode(number: u16) -> StatusCode {
+	match StatusCode::try_from(number) {
+		Ok(status) => {
+			status
+		},
+		Err(_) => {
+			StatusCode::BadRequest
+		},
+	}
+}
+
+impl From<(u16, &'static str)> for Response {
+	fn from(tuple: (u16, &'static str)) -> Response {
+		Response::new()
+			.with_status(convertToStatusCode(tuple.0))
+			.with_body(tuple.1)
+	}
+}
+
+impl From<(u16, &'static str)> for ArcError {
+	fn from(tuple: (u16, &'static str)) -> ArcError {
+		let status = convertToStatusCode(tuple.0);
+		ArcError(status, tuple.1.to_owned())
+	}
+}
+
+impl From<Response> for hyper::Response {
+	fn from(res: Response) -> hyper::Response {
+		res.inner
+	}
+}

--- a/src/ArcProto/middleware.rs
+++ b/src/ArcProto/middleware.rs
@@ -1,18 +1,12 @@
-use hyper::{Request, Response};
-use ArcProto::{ArcResult, ArcError, arc};
+use ArcCore::{Request};
+use ArcProto::{ArcResult, arc};
 
-pub trait MiddleWare: Sync + Send
-{
-	type R: Into<Response>;
-	type E: Into<ArcError>;
-	fn call(&self, request: Request) -> ArcResult<Self::R, Self::E>;
+pub trait MiddleWare: Sync + Send {
+	fn call(&self, request: Request) -> ArcResult;
 }
 
-impl MiddleWare for Vec<Box<MiddleWare<R = Response, E = ArcError>>>
-{
-	type R = Response;
-	type E = ArcError;
-	fn call(&self, request: Request) -> ArcResult<Self::R, Self::E> {
+impl MiddleWare for Vec<Box<MiddleWare>> {
+	fn call(&self, request: Request) -> ArcResult {
 		self
 			.iter()
 			.fold(
@@ -26,9 +20,8 @@ impl MiddleWare for Vec<Box<MiddleWare<R = Response, E = ArcError>>>
 
 #[macro_export]
 macro_rules! mw {
-    ($($middlewares:expr), +) => {{
-			let middleWares: Vec<Box<MiddleWare<R = Response, E = ArcError>>> = vec![$(Box::new($middlewares)), +];
-      middleWares
-		}};
+	($($middlewares:expr), +) => {{
+		let middleWares: Vec<Box<MiddleWare>> = vec![$(Box::new($middlewares)), +];
+     middleWares
+	}};
 }
-

--- a/src/ArcProto/mod.rs
+++ b/src/ArcProto/mod.rs
@@ -1,12 +1,13 @@
 mod service;
 mod error;
-
+mod convert;
 #[macro_use]
 mod middleware;
 
 pub use self::middleware::*;
 pub use self::service::*;
 pub use self::error::*;
+pub use self::convert::*;
 
 pub mod arc {
 	pub use super::error::ArcResult::*;

--- a/src/ArcProto/service.rs
+++ b/src/ArcProto/service.rs
@@ -1,50 +1,53 @@
-use hyper::{Response, Request, Error, StatusCode};
-use futures::{future, Future, IntoFuture};
-use ArcProto::{MiddleWare, arc, ArcError};
+use hyper::{Response, Error};
+use ArcCore::{Request, self};
+use futures::{Future, IntoFuture};
+use ArcProto::{MiddleWare, arc};
 
 pub trait ArcService: Send + Sync {
-	fn call (&self, req: Request) -> ResponseFuture;
+	fn call (&self, req: Request, res: Response) -> ResponseFuture;
 }
 
 type ResponseFuture = Box<Future<Item = Response, Error = Error>>;
 
 impl<B, H, A> ArcService for (B, H, A)
 where
-		B: MiddleWare<R = Response, E = ArcError>  + Sync + Send,
+		B: MiddleWare + Sync + Send,
 		H: ArcService + Sync + Send,
 		A: Fn(ResponseFuture) -> ResponseFuture + Sync + Send,
 {
-	fn call(&self, req: Request) -> ResponseFuture {
+	fn call(&self, req: Request, res: Response) -> ResponseFuture {
 		let request = match self.0.call(req) {
 			arc::Ok(request) => request,
 			arc::Res(res) => {
 				return box Ok(res.into()).into_future()
 			}
 			arc::Err(e) => {
-				return box Ok(e.into()).into_future()
+				let res: ArcCore::Response = e.into();
+				return box Ok(Response::from(res)).into_future()
 			}
 		};
-		let response = (self.1).call(request);
+		let response = (self.1).call(request, res);
 		(self.2)(response)
 	}
 }
 
 impl<B, H> ArcService for (B, H)
 where
-		B: MiddleWare<R = Response, E = ArcError> + Sync + Send,
+		B: MiddleWare + Sync + Send,
 		H: ArcService + Sync + Send,
 {
-	fn call(&self, req: Request) -> ResponseFuture {
+	fn call(&self, req: Request, res: Response) -> ResponseFuture {
 		let request = match self.0.call(req) {
 			arc::Ok(request) => request,
 			arc::Res(res) => {
 				return box Ok(res.into()).into_future()
 			}
 			arc::Err(e) => {
-				return box Ok(e.into()).into_future()
+				let res: ArcCore::Response = e.into();
+				return box Ok(Response::from(res)).into_future()
 			}
 		};
-		(self.1).call(request)
+		(self.1).call(request, res)
 	}
 
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,7 +26,8 @@ mod ArcProto;
 use impl_service::{service, middleware};
 use ArcCore::ArcReactor;
 use ArcRouting::*;
-use hyper::{Request, Response, Error, StatusCode};
+use hyper::{Response, Error, StatusCode};
+use ArcCore::{Request};
 use futures::future::Future;
 use futures::prelude::{async_block};
 use ArcProto::*;
@@ -46,9 +47,9 @@ fn main() {
 }
 
 #[service]
-fn RequestHandler(_request: Request) {
+fn RequestHandler(_request: Request, res: Response) {
 	println!("Post Request!");
-	let res =	Response::new()
+	let res =	res
 		.with_status(StatusCode::Ok)
 		.with_body("Hello World");
 
@@ -57,7 +58,7 @@ fn RequestHandler(_request: Request) {
 
 #[middleware]
 fn middleware(req: Request){
-	println!("middleware 1: {}, {}", req.path(), req.method());
+	println!("middleware 1: {:?}", &req);
 	if req.path() != "/" {
 		return arc::Err("Failed to get the data!".into())
 	}
@@ -69,20 +70,20 @@ fn middleware(req: Request){
 fn middleware2(req: Request) {
 	println!("middleware 2: {}, {}", req.path(), req.method());
 	if req.path() != "/" {
-		return arc::Err("Failed to get the data!".into())
+		return arc::Err((401, "failed to acquire type info!").into())
 	}
 	
-	if true {
-		return arc::Res((401, "failed to acquire type info!").convert())
+	if false {
+		return arc::Res((401, "failed to acquire type info!").into())
 	}
 
 	return arc::Ok(req)
 }
 
 #[service]
-fn GetRequest(_req: Request) {
-	return
-	Ok(Response::new()
+fn GetRequest(_req: Request, res: Response) {
+	return Ok(
+		res
 		.with_body("hello world".as_bytes())
 	)
 }


### PR DESCRIPTION
- added custom Request/Response Structs.
- Implemented From<(u16, &'static str)> for arcError, ArcCore::Response, ArcCore::Request.
- Implemented From<ArcCore::Response> for hyper::Response.
- Removed trait bounds from ArcResult.
- added redirect convinience method for ArcCore::Response.
- changed definition of ArcService, call method now takes request/response.

TODO
- add AnyMap, QueryParser, RouteParamsParser to ArcCore::Request.